### PR TITLE
fix: repair preprocessing and FASTA input handling

### DIFF
--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -432,12 +432,14 @@ class pyhmmer_manager:
 			self.filter_to_best_hits()
 			try:
 				self.to_hmm_file(hmm_output)
-			except:
-				print(output, "cannot be created. HMM search failed. This file will be skipped.")
+			except Exception as exc:
+				output_name = hmm_output if hmm_output is not None else "HMM output"
+				raise RuntimeError(f"{output_name} cannot be created. HMM search failed.") from exc
 
-		except:
-			print(output, "failed to run through HMMER!")
+		except Exception as exc:
 			self.best_hits = None
+			output_name = hmm_output if hmm_output is not None else "HMM output"
+			raise RuntimeError(f"{output_name} failed to run through HMMER.") from exc
 
 class new_pyhmmer_manager:
 	def __init__(self, compress = True):

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -461,7 +461,10 @@ class new_pyhmmer_manager:
 		
 	def load_hmm_from_file(self, hmm_file):
 		ar = agnostic_reader(hmm_file)
-		hmm_text = ar.read()
+		try:
+			hmm_text = ar.read()
+		finally:
+			ar.close()
 		hmm_io = io.BytesIO(hmm_text.encode(encoding = "ascii"))
 		self.convert_hmm_to_digital(hmm_io)
 			
@@ -868,6 +871,13 @@ class agnostic_reader:
 			
 	def __iter__(self):
 		return agnostic_reader_iterator(self)
+
+	def read(self):
+		"""Return the full file contents as text."""
+		contents = self.handle.read()
+		if self.is_gz and isinstance(contents, bytes):
+			return contents.decode(encoding = "ascii")
+		return contents
 		
 	def close(self):
 		self.handle.close()

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -110,6 +110,15 @@ def convert_float_array_32(bytestring):
 def convert_float_array_64(bytestring):
 	return np.frombuffer(bytestring, dtype = np.float64)
 
+
+def normalise_pyhmmer_text(value):
+	"""Return PyHMMER text fields as Python strings."""
+	if value is None:
+		return None
+	if isinstance(value, bytes):
+		return value.decode("utf-8")
+	return str(value)
+
 def read_fasta(file):
 	cur_seq = ""
 	cur_prot = ""
@@ -298,15 +307,13 @@ class pyhmmer_manager:
 		
 		for model in top_hits:
 			for hit in model:
-				target_name = hit.name.decode()
-				target_acc = hit.accession
+				target_name = normalise_pyhmmer_text(hit.name)
+				target_acc = normalise_pyhmmer_text(hit.accession)
 				if target_acc is None:
 					target_acc = "-"
-				else:
-					target_acc = target_acc.decode()
 				
-				query_name = hit.best_domain.alignment.hmm_name.decode()
-				query_acc = hit.best_domain.alignment.hmm_accession.decode()
+				query_name = normalise_pyhmmer_text(hit.best_domain.alignment.hmm_name)
+				query_acc = normalise_pyhmmer_text(hit.best_domain.alignment.hmm_accession)
 				
 				full_seq_evalue = "%.2g" % hit.evalue
 				full_seq_score = round(hit.score, 1)
@@ -512,15 +519,13 @@ class new_pyhmmer_manager:
 		
 		for model in top_hits:
 			for hit in model:
-				target_name = hit.name.decode()
-				target_acc = hit.accession
+				target_name = normalise_pyhmmer_text(hit.name)
+				target_acc = normalise_pyhmmer_text(hit.accession)
 				if target_acc is None:
 					target_acc = "-"
-				else:
-					target_acc = target_acc.decode()
 				
-				query_name = hit.best_domain.alignment.hmm_name.decode()
-				query_acc = hit.best_domain.alignment.hmm_accession.decode()
+				query_name = normalise_pyhmmer_text(hit.best_domain.alignment.hmm_name)
+				query_acc = normalise_pyhmmer_text(hit.best_domain.alignment.hmm_accession)
 				
 				full_seq_evalue = "%.2g" % hit.evalue
 				full_seq_score = round(hit.score, 1)

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -804,7 +804,6 @@ class new_pyrodigal_manager:
 			
 			for seq in self.current_genes:
 				self.current_genes[seq].write_translations(self.genes_aa, seq)
-				self.protein_seqs[seq] = {}
 				
 			self.genes_aa = self.genes_aa.getvalue()
 		

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -119,31 +119,52 @@ def normalise_pyhmmer_text(value):
 		return value.decode("utf-8")
 	return str(value)
 
+
+def decode_text_buffer(value, file_path):
+	"""Decode FASTAAI text inputs with a small compatibility fallback."""
+	for encoding in ("utf-8", "latin-1"):
+		try:
+			return value.decode(encoding)
+		except UnicodeDecodeError:
+			continue
+	raise ValueError("Unable to decode text input: " + str(file_path))
+
 def read_fasta(file):
 	cur_seq = ""
 	cur_prot = ""
+	defline = ""
 	
 	contents = {}
 	deflines = {}
 	
 	fasta = agnostic_reader(file)
-	for line in fasta:
+	for line_number, line in enumerate(fasta, start = 1):
+		line = line.strip()
+		if len(line) == 0:
+			continue
+
 		if line.startswith(">"):
-			if len(cur_seq) > 0:
+			if len(cur_prot) > 0:
 				contents[cur_prot] = cur_seq
 				deflines[cur_prot] = defline
 				
 			cur_seq = ""
-			cur_prot = line.strip().split()[0][1:]
-			defline = line.strip()[len(cur_prot)+1 :].strip()
+			cur_prot = line.split()[0][1:]
+			if len(cur_prot) == 0:
+				fasta.close()
+				raise ValueError("Malformed FASTA in " + str(file) + ": empty header at line " + str(line_number))
+			defline = line[len(cur_prot)+1 :].strip()
 			
 		else:
-			cur_seq += line.strip()
+			if len(cur_prot) == 0:
+				fasta.close()
+				raise ValueError("Malformed FASTA in " + str(file) + ": sequence data found before the first header at line " + str(line_number))
+			cur_seq += line
 				
 	fasta.close()
 	
 	#Final iter
-	if len(cur_seq) > 0:
+	if len(cur_prot) > 0:
 		contents[cur_prot] = cur_seq
 		deflines[cur_prot] = defline
 		
@@ -845,17 +866,14 @@ class new_pyrodigal_manager:
 class agnostic_reader_iterator:
 	def __init__(self, reader):
 		self.handle_ = reader.handle
-		self.is_gz_ = reader.is_gz
+		self.path_ = reader.path
 		
 	def __next__(self):
-		if self.is_gz_:
-			line = self.handle_.readline().decode()
-		else:
-			line = self.handle_.readline()
+		line = self.handle_.readline()
 		
 		#Ezpz EOF check
 		if line:
-			return line
+			return decode_text_buffer(line, self.path_)
 		else:
 			raise StopIteration
 
@@ -871,9 +889,9 @@ class agnostic_reader:
 		self.is_gz = is_gz
 		
 		if is_gz:
-			self.handle = gzip.open(self.path)
+			self.handle = gzip.open(self.path, "rb")
 		else:
-			self.handle = open(self.path)
+			self.handle = open(self.path, "rb")
 			
 	def __iter__(self):
 		return agnostic_reader_iterator(self)
@@ -881,9 +899,7 @@ class agnostic_reader:
 	def read(self):
 		"""Return the full file contents as text."""
 		contents = self.handle.read()
-		if self.is_gz and isinstance(contents, bytes):
-			return contents.decode(encoding = "ascii")
-		return contents
+		return decode_text_buffer(contents, self.path)
 		
 	def close(self):
 		self.handle.close()
@@ -4896,5 +4912,3 @@ def main():
 	
 if __name__ == "__main__":
 	main()
-
-	

--- a/tests/test_fasta_input.py
+++ b/tests/test_fasta_input.py
@@ -1,0 +1,52 @@
+"""Tests for FASTA parsing and text-input decoding."""
+
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastaai.fastaai import agnostic_reader
+from fastaai.fastaai import read_fasta
+
+
+class FastaInputTests(unittest.TestCase):
+	"""Verify FASTA parsing handles malformed and mixed-encoding inputs."""
+
+	def test_read_fasta_rejects_sequence_before_header(self):
+		"""Reject malformed FASTA files with sequence text before a header."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			test_path = Path(tempdir) / "bad.faa"
+			test_path.write_text("MPEPTIDE\n>seq1\nAAAA\n", encoding = "ascii")
+
+			with self.assertRaises(ValueError) as context:
+				read_fasta(str(test_path))
+
+		self.assertIn("sequence data found before the first header", str(context.exception))
+
+	def test_read_fasta_skips_blank_leading_lines(self):
+		"""Allow blank lines before the first FASTA record."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			test_path = Path(tempdir) / "good.faa"
+			test_path.write_text("\n\n>seq1 sample\nAAAA\n", encoding = "ascii")
+
+			contents, descriptions = read_fasta(str(test_path))
+
+		self.assertEqual(contents["seq1"], "AAAA")
+		self.assertEqual(descriptions["seq1"], "sample")
+
+	def test_agnostic_reader_falls_back_to_latin_1(self):
+		"""Decode non-UTF-8 text inputs with a Latin-1 fallback."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			test_path = Path(tempdir) / "latin1.txt.gz"
+			with gzip.open(test_path, "wb") as handle:
+				handle.write(b"caf\xe9\n")
+
+			reader = agnostic_reader(str(test_path))
+			try:
+				self.assertEqual(reader.read(), "caf" + chr(233) + "\n")
+			finally:
+				reader.close()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_genome_to_protein.py
+++ b/tests/test_genome_to_protein.py
@@ -1,0 +1,32 @@
+"""Tests for the genome-to-protein preprocessing path."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastaai.fastaai import new_pyrodigal_manager
+
+
+class GenomeToProteinTests(unittest.TestCase):
+	"""Verify predicted proteins remain available after export."""
+
+	def test_run_for_fastaai_keeps_predicted_proteins_in_memory(self):
+		"""Preserve in-memory proteins for the later HMM step."""
+		example_genome = Path(__file__).resolve().parents[1] / "example_genomes"
+		example_genome = example_genome / "Xanthomonas_albilineans_GCA_000962915_1.fna.gz"
+
+		with tempfile.TemporaryDirectory() as tempdir:
+			output_base = Path(tempdir) / "proteins.faa"
+			manager = new_pyrodigal_manager(trans_tables=[11, 4], meta=False, verbose=False)
+			manager.run_for_fastaai(
+				genome_file=str(example_genome),
+				compress=True,
+				outaa=str(output_base),
+			)
+
+			total_proteins = sum(len(proteins) for proteins in manager.protein_seqs.values())
+			self.assertGreater(total_proteins, 0)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_hmm_loader.py
+++ b/tests/test_hmm_loader.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from fastaai.fastaai import agnostic_reader
 from fastaai.fastaai import find_hmm
 from fastaai.fastaai import new_pyhmmer_manager
+from fastaai.fastaai import normalise_pyhmmer_text
 from fastaai.fastaai import pyhmmer_manager
 
 
@@ -41,6 +42,12 @@ class AgnosticReaderTests(unittest.TestCase):
 
 class HmmLoaderTests(unittest.TestCase):
 	"""Verify the bundled HMM file can be loaded."""
+
+	def test_normalise_pyhmmer_text_accepts_bytes_and_strings(self):
+		"""Accept both legacy and current PyHMMER text field types."""
+		self.assertEqual(normalise_pyhmmer_text(b"protein_1"), "protein_1")
+		self.assertEqual(normalise_pyhmmer_text("protein_2"), "protein_2")
+		self.assertIsNone(normalise_pyhmmer_text(None))
 
 	def test_load_hmm_from_file(self):
 		"""Load the bundled HMM models without a reader failure."""

--- a/tests/test_hmm_loader.py
+++ b/tests/test_hmm_loader.py
@@ -1,0 +1,51 @@
+"""Tests for HMM loading and agnostic file reading."""
+
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastaai.fastaai import agnostic_reader
+from fastaai.fastaai import find_hmm
+from fastaai.fastaai import new_pyhmmer_manager
+
+
+class AgnosticReaderTests(unittest.TestCase):
+	"""Verify plain-text and gzipped reads return text."""
+
+	def test_read_plain_text(self):
+		"""Read plain text as a string."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			test_path = Path(tempdir) / "plain.txt"
+			test_path.write_text("plain-text\n", encoding="ascii")
+			reader = agnostic_reader(str(test_path))
+			try:
+				self.assertEqual(reader.read(), "plain-text\n")
+			finally:
+				reader.close()
+
+	def test_read_gzipped_text(self):
+		"""Read gzipped text as a decoded string."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			test_path = Path(tempdir) / "plain.txt.gz"
+			with gzip.open(test_path, "wb") as handle:
+				handle.write(b"gz-text\n")
+			reader = agnostic_reader(str(test_path))
+			try:
+				self.assertEqual(reader.read(), "gz-text\n")
+			finally:
+				reader.close()
+
+
+class HmmLoaderTests(unittest.TestCase):
+	"""Verify the bundled HMM file can be loaded."""
+
+	def test_load_hmm_from_file(self):
+		"""Load the bundled HMM models without a reader failure."""
+		manager = new_pyhmmer_manager(compress=False)
+		manager.load_hmm_from_file(find_hmm())
+		self.assertGreater(len(manager.hmm_models), 0)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_hmm_loader.py
+++ b/tests/test_hmm_loader.py
@@ -4,10 +4,12 @@ import gzip
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fastaai.fastaai import agnostic_reader
 from fastaai.fastaai import find_hmm
 from fastaai.fastaai import new_pyhmmer_manager
+from fastaai.fastaai import pyhmmer_manager
 
 
 class AgnosticReaderTests(unittest.TestCase):
@@ -45,6 +47,15 @@ class HmmLoaderTests(unittest.TestCase):
 		manager = new_pyhmmer_manager(compress=False)
 		manager.load_hmm_from_file(find_hmm())
 		self.assertGreater(len(manager.hmm_models), 0)
+
+	def test_run_for_fastaai_raises_meaningful_error(self):
+		"""Surface HMM failures instead of masking them."""
+		manager = pyhmmer_manager(do_compress=False)
+		with patch.object(manager, "execute_search", side_effect=ValueError("boom")):
+			with self.assertRaises(RuntimeError) as context:
+				manager.run_for_fastaai({}, None)
+		self.assertIn("failed to run through HMMER", str(context.exception))
+		self.assertIsInstance(context.exception.__cause__, ValueError)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix preprocessing failures that could produce empty databases or hide the original input error.

- add plain-text and gzip read support to the HMM loader
- preserve predicted proteins after export
- accept both byte and string fields from PyHMMER
- give clear errors for malformed or non-UTF-8 FASTA input

Tests: `python -m unittest tests.test_hmm_loader tests.test_genome_to_protein tests.test_fasta_input` (9 passed)

Closes #14
Closes #18
Closes #23
Addresses #26
