### PR TITLE
fix: make database-query workers reliable

### DIFF
--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -2815,21 +2815,19 @@ def one_work(placeholder):
 				aai_ests[no_hit] = 0
 				print(*aai_ests, sep = "\t", file = outwriter)
 		
-		prog_queue.put(q)
-	
-	prog_queue.put("done")
+	result_file = None
 	if style == "matrix":
 		if store:
 			if len(holder) == 0:
-				return None
+				return (len(query_grouping), None)
 			hold_together = np.vstack(holder)
 			np.savetxt(group_id, hold_together, delimiter = "\t", fmt='%4d')
+			result_file = group_id
 		else:
 			outwriter.close()
-			if len(query_grouping) == 0:
-				return None
-		return group_id
-	return None
+			if len(query_grouping) > 0:
+				result_file = group_id
+	return (len(query_grouping), result_file)
 
 def two_work(i):
 	if store:
@@ -2882,10 +2880,6 @@ def on_disk_init(query_database_path, target_database_path, num_tgt, query_queue
 	#Suppress div by zero warning - it's handled.
 	np.seterr(divide='ignore')
 	
-	if style == "matrix":
-		global outwriter
-		outwriter = open(group_id, "w")
-		
 	global prog_queue
 	prog_queue = progress_queue
 	
@@ -2903,6 +2897,7 @@ def on_disk_init(query_database_path, target_database_path, num_tgt, query_queue
 	
 def on_disk_work_one(placeholder):
 	curs = database.cursor()
+	output_rows = []
 	for q in query_grouping:
 		results = []
 		qname = _qnames[q]
@@ -3011,17 +3006,17 @@ def on_disk_work_one(placeholder):
 		else:
 			aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = True)
 			aai_ests[no_hit] = 0
-			print(*aai_ests, sep = "\t", file = outwriter)
-		
-		prog_queue.put(q)
+			output_rows.append("\t".join(str(value) for value in aai_ests))
 		
 	curs.close()
-	prog_queue.put("done")
 	if style == "matrix":
-		outwriter.close()
 		if len(query_grouping) == 0:
-			return None
-		return group_id
+			return (len(query_grouping), None)
+		with open(group_id, "w") as outwriter:
+			if len(output_rows) > 0:
+				outwriter.write("\n".join(output_rows) + "\n")
+		return (len(query_grouping), group_id)
+	return (len(query_grouping), None)
 	
 def on_disk_work_two(i):
 	outwriter.close()
@@ -3215,10 +3210,6 @@ class db_db_remake:
 			query_groups.append(np.arange(grouping[0], grouping[1]))
 		self.num_result_groups = len(query_groups)
 		
-		result_queue = multiprocessing.Queue()
-		remaining_procs = self.threads
-		still_going = True
-		
 		pool = multiprocessing.Pool(self.threads, initializer = one_init, 
 		initargs = (ql, #ql 
 					tl, #tl
@@ -3230,34 +3221,30 @@ class db_db_remake:
 					self.style, #sty
 					self.output_base, #output_dir
 					self.store_mat, #store_results
-					result_queue, #progress_queue
+					None, #progress_queue
 					self.query_names, #qnames
 					self.target_names, #tnames
 					tempdir_path,)) #temp_dir
 		
 		some_results = pool.imap(one_work, query_groups)
 		
-		while still_going:
-			item = result_queue.get() 
-			if item == "done":
-				remaining_procs -= 1
-				if remaining_procs == 0:
-					still_going = False
-			else:
-				if self.verbose:
-					tracker.update()
-				else:
-					pass
-		
 		if self.style == "matrix":
-			result_files = [result for result in some_results if result is not None]
+			result_files = []
+			for processed_queries, result_file in some_results:
+				for i in range(0, processed_queries):
+					if self.verbose:
+						tracker.update()
+				if result_file is not None:
+					result_files.append(result_file)
 			
 			pool.close()
 		
 			self.write_mat_from_files(result_files, tempdir_path)
 		else:
-			for result in some_results:
-				pass
+			for processed_queries, result_file in some_results:
+				for i in range(0, processed_queries):
+					if self.verbose:
+						tracker.update()
 			pool.close()
 
 	#This needs to be implemented from existing code.
@@ -3266,10 +3253,6 @@ class db_db_remake:
 		if self.style == "matrix":
 			self.store_mat = False
 			
-		result_queue = multiprocessing.Queue()
-		remaining_procs = self.threads
-		still_going = True
-		
 		if self.verbose:
 			tracker = progress_tracker(total = self.num_queries, message = "Calculating AAI")
 		else:
@@ -3292,7 +3275,7 @@ class db_db_remake:
 					self.do_sd, #sd
 					self.style, #sty
 					self.output_base, #output_dir
-					result_queue, #progress_queue
+					None, #progress_queue
 					self.query_names, #qnames
 					self.target_names, #tnames
 					self.valids, #valids
@@ -3300,23 +3283,19 @@ class db_db_remake:
 		
 		some_results = pool.imap(on_disk_work_one, query_groups)
 		
-		while still_going:
-			item = result_queue.get() 
-			if item == "done":
-				remaining_procs -= 1
-				if remaining_procs == 0:
-					still_going = False
-			else:
-				if self.verbose:
-					tracker.update()
-				else:
-					pass
-		
 		if self.style == "matrix":
-			result_files = [result for result in some_results if result is not None]
+			result_files = []
+			for processed_queries, result_file in some_results:
+				for i in range(0, processed_queries):
+					if self.verbose:
+						tracker.update()
+				if result_file is not None:
+					result_files.append(result_file)
 		else:
-			for result in some_results:
-				pass
+			for processed_queries, result_file in some_results:
+				for i in range(0, processed_queries):
+					if self.verbose:
+						tracker.update()
 			
 		pool.close()
 			

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -2818,7 +2818,17 @@ def one_work(placeholder):
 		prog_queue.put(q)
 	
 	prog_queue.put("done")
-	
+	if style == "matrix":
+		if store:
+			if len(holder) == 0:
+				return None
+			hold_together = np.vstack(holder)
+			np.savetxt(group_id, hold_together, delimiter = "\t", fmt='%4d')
+		else:
+			outwriter.close()
+			if len(query_grouping) == 0:
+				return None
+		return group_id
 	return None
 
 def two_work(i):
@@ -3007,6 +3017,11 @@ def on_disk_work_one(placeholder):
 		
 	curs.close()
 	prog_queue.put("done")
+	if style == "matrix":
+		outwriter.close()
+		if len(query_grouping) == 0:
+			return None
+		return group_id
 	
 def on_disk_work_two(i):
 	outwriter.close()
@@ -3233,15 +3248,14 @@ class db_db_remake:
 					pass
 		
 		if self.style == "matrix":
-			result_files = []
-			
-			for result in pool.map(two_work, range(0, self.threads)):
-				result_files.append(result)
+			result_files = [result for result in some_results if result is not None]
 			
 			pool.close()
 		
 			self.write_mat_from_files(result_files, tempdir_path)
 		else:
+			for result in some_results:
+				pass
 			pool.close()
 
 	#This needs to be implemented from existing code.
@@ -3296,9 +3310,10 @@ class db_db_remake:
 					pass
 		
 		if self.style == "matrix":
-			result_files = []
-			for result in pool.map(on_disk_work_two, range(0, self.threads)):
-				result_files.append(result)
+			result_files = [result for result in some_results if result is not None]
+		else:
+			for result in some_results:
+				pass
 			
 		pool.close()
 			

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -2664,6 +2664,18 @@ def parse_accession(acc):
 		pickle.dump([ql, tl], out)
 		
 	return([acc, out_file])
+
+
+def flatten_cached_targets(target_hits, selection):
+	"""Return cached target-hit arrays as one flat integer array."""
+	if len(selection) == 0:
+		return np.empty(0, dtype = np.int32)
+
+	selected_hits = [target_hits[int(index)] for index in selection]
+	if len(selected_hits) == 1:
+		return np.asarray(selected_hits[0], dtype = np.int32)
+
+	return np.concatenate(selected_hits).astype(np.int32, copy = False)
 			
 #all of this is exclusive to the in-mem approach for db db query
 def one_init(ql, tl, num_tgt, tgak, tpres, sd, sty, output_dir, store_results, progress_queue, qnames, tnames, temp_dir):
@@ -2721,7 +2733,10 @@ def one_work(task):
 			results = []
 			for acc in local_qgak[q][0]:
 				if acc in _ql[q]:
-					these_intersections = np.bincount(np.concatenate(_tl[acc][_ql[q][acc]]), minlength = _nt)
+					these_intersections = np.bincount(
+						flatten_cached_targets(_tl[acc], _ql[q][acc]),
+						minlength = _nt,
+					)
 				else:
 					these_intersections = np.zeros(_nt, dtype = np.int32)
 				results.append(these_intersections)

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -3063,6 +3063,7 @@ class db_db_remake:
 			
 		self.query_names = None
 		self.target_names = None
+		self.num_result_groups = 0
 		
 		self.num_queries = None
 		self.num_targets = None
@@ -3212,6 +3213,7 @@ class db_db_remake:
 		query_groups = []
 		for grouping in split_seq_indices(np.arange(self.num_queries), self.threads):
 			query_groups.append(np.arange(grouping[0], grouping[1]))
+		self.num_result_groups = len(query_groups)
 		
 		result_queue = multiprocessing.Queue()
 		remaining_procs = self.threads
@@ -3276,6 +3278,7 @@ class db_db_remake:
 		query_groups = []
 		for grouping in split_seq_indices(np.arange(self.num_queries), self.threads):
 			query_groups.append(np.arange(grouping[0], grouping[1]))
+		self.num_result_groups = len(query_groups)
 		
 		#query_database_path, target_database_path, num_tgt, query_queue, target_gak, tpres, sd, 
 		#sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir
@@ -3320,9 +3323,20 @@ class db_db_remake:
 		if self.style == "matrix":
 			self.write_mat_from_files(result_files, tempdir_path)
 			
+	def validate_result_files(self, result_files):
+		"""Validate matrix partial result files before combining them."""
+		if len(result_files) != self.num_result_groups:
+			raise RuntimeError("Unexpected number of matrix partial result files.")
+		if len(set(result_files)) != len(result_files):
+			raise RuntimeError("Duplicate matrix partial result files detected.")
+		missing_files = [path for path in result_files if not os.path.exists(path)]
+		if len(missing_files) > 0:
+			raise RuntimeError("Missing matrix partial result files detected.")
+
 	def write_mat_from_files(self, result_files, tempdir_path):
 		#tempdir_path = os.path.normpath(self.output_base+"/temp")
-	
+
+		self.validate_result_files(result_files)
 		result_files = sorted_nicely(result_files)
 		
 		#print("Combining:")
@@ -3330,7 +3344,7 @@ class db_db_remake:
 		#	print(f)
 		
 		if self.verbose:
-			tracker = progress_tracker(total = self.threads, step_size = 2, message = "Finalizing results.")
+			tracker = progress_tracker(total = len(result_files), step_size = 2, message = "Finalizing results.")
 		else:
 			print("\nFinalizing results.")
 		

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -2666,29 +2666,19 @@ def parse_accession(acc):
 	return([acc, out_file])
 			
 #all of this is exclusive to the in-mem approach for db db query
-def one_init(ql, tl, num_tgt, qgak_queue, tgak, tpres, sd, sty, output_dir, store_results, progress_queue, qnames, tnames, temp_dir):
+def one_init(ql, tl, num_tgt, tgak, tpres, sd, sty, output_dir, store_results, progress_queue, qnames, tnames, temp_dir):
 	global _ql
 	_ql = ql
 	global _tl
 	_tl = tl
 	global _nt
 	_nt = num_tgt
-	
-	qgak_data = qgak_queue.get()
-	
+
 	global out_base
 	out_base = output_dir
-	
-	global group_id
-	group_id = os.path.normpath(temp_dir + "/partial_results_group_" + str(qgak_data[0])+ ".txt")
-	
-	global _qgak
-	_qgak = qgak_data[1]
-	
-	global query_grouping
-	query_grouping = qgak_data[2]
-	
-	qgak_data = None
+
+	global temp_path
+	temp_path = temp_dir
 	
 	global _tgak
 	_tgak = tgak
@@ -2708,12 +2698,6 @@ def one_init(ql, tl, num_tgt, qgak_queue, tgak, tpres, sd, sty, output_dir, stor
 	
 	global store
 	store = store_results
-	if store:
-		global holder
-		holder = []
-	else:
-		global outwriter
-		outwriter = open(group_id, "w")
 		
 	global prog_queue
 	prog_queue = progress_queue
@@ -2724,110 +2708,84 @@ def one_init(ql, tl, num_tgt, qgak_queue, tgak, tpres, sd, sty, output_dir, stor
 	global _tnames
 	_tnames = tnames
 	
-def one_work(placeholder):	
-	for q in query_grouping:
-		results = []
-		#We also need to count the accs in the query genome, but which are not part of the inner join.
-		for acc in _qgak[q][0]:
-			if acc in _ql[q]:
-				#the bincount is intersections.
-				these_intersections = np.bincount(np.concatenate(_tl[acc][_ql[q][acc]]), minlength = _nt)
-			else:
-				#there are no intersections even though this accession is shared with at least one target
-				#number of intersects is all zeros
-				these_intersections = np.zeros(_nt, dtype = np.int32)
-			
-			#Append the counts or zeros, either way.
-			results.append(these_intersections)
-				
-		results = np.vstack(results)
-		
-		target_kmer_counts = _tgak[_qgak[q][0], :]
-		
-		#unions = size(A) + size(B) - size(intersections(A, B)) 
-		#unions = target_kmer_counts + query_kmers_by_acc - intersections
-		unions = np.subtract(np.add(target_kmer_counts, _qgak[q][1][:, None]), results)
-		
-		#These are now jaccards, not #intersections
-		results = np.divide(results, unions)
-		
-		shared_acc_counts = np.sum(_tpres[_qgak[q][0], :], axis = 0)
-		
-		no_hit = np.where(shared_acc_counts == 0)
-		
-		jaccard_averages = np.divide(np.sum(results, axis = 0), shared_acc_counts)
+def one_work(task):	
+	task_id, local_qgak, query_grouping = task
+	group_id = os.path.normpath(temp_path + "/partial_results_group_" + str(task_id)+ ".txt")
+	holder = []
+	outwriter = None
+	if style == "matrix" and not store:
+		outwriter = open(group_id, "w")
 
-		#Skip SD if output is matrix
-		if style == "tsv":
-			aai_ests = numpy_kaai_to_aai(jaccard_averages)
+	try:
+		for q in query_grouping:
+			results = []
+			for acc in local_qgak[q][0]:
+				if acc in _ql[q]:
+					these_intersections = np.bincount(np.concatenate(_tl[acc][_ql[q][acc]]), minlength = _nt)
+				else:
+					these_intersections = np.zeros(_nt, dtype = np.int32)
+				results.append(these_intersections)
 
-			if do_sd:
-				#find diffs from means; this includes indicies corresponding to unshared SCPs that should not be included. 
-				results = results - jaccard_averages
-				
-				#fix those corresponding indicies to not contribute to the final SD.
-				results[np.logical_not(_tpres[_qgak[q][0], :])] = 0
-				#results[np.nonzero(has_accs == 0)] = 0
-				
-				#Square them; 0^2 = 0, so we don't have to think about the fixed indices any more.
-				results = np.square(results)
-				#Sum squares and divide by shared acc. count, the sqrt to get SD.
-				jaccard_SDs = np.sqrt(np.divide(np.sum(results, axis = 0), shared_acc_counts))
-				jaccard_SDs = np.round(jaccard_SDs, 4).astype(str)
-				
+			results = np.vstack(results)
+			target_kmer_counts = _tgak[local_qgak[q][0], :]
+			unions = np.subtract(np.add(target_kmer_counts, local_qgak[q][1][:, None]), results)
+			results = np.divide(results, unions)
+			shared_acc_counts = np.sum(_tpres[local_qgak[q][0], :], axis = 0)
 			no_hit = np.where(shared_acc_counts == 0)
-			
-			#addtl.shape[0] is the query acc count
-			possible_hits = np.minimum(_qgak[q][0].shape[0], _tct).astype(str)
-			
-			jaccard_averages = np.round(jaccard_averages, 4).astype(str)
-			shared_acc_counts = shared_acc_counts.astype(str)
-			
-			jaccard_averages[no_hit] = "N/A"
-			aai_ests[no_hit] = "N/A"
-			shared_acc_counts[no_hit] = "N/A"
-			possible_hits[no_hit] = "N/A"
+			jaccard_averages = np.divide(np.sum(results, axis = 0), shared_acc_counts)
+
+			if style == "tsv":
+				aai_ests = numpy_kaai_to_aai(jaccard_averages)
+
+				if do_sd:
+					results = results - jaccard_averages
+					results[np.logical_not(_tpres[local_qgak[q][0], :])] = 0
+					results = np.square(results)
+					jaccard_SDs = np.sqrt(np.divide(np.sum(results, axis = 0), shared_acc_counts))
+					jaccard_SDs = np.round(jaccard_SDs, 4).astype(str)
 				
-			qname = _qnames[q]
+				possible_hits = np.minimum(local_qgak[q][0].shape[0], _tct).astype(str)
+				jaccard_averages = np.round(jaccard_averages, 4).astype(str)
+				shared_acc_counts = shared_acc_counts.astype(str)
+				jaccard_averages[no_hit] = "N/A"
+				aai_ests[no_hit] = "N/A"
+				shared_acc_counts[no_hit] = "N/A"
+				possible_hits[no_hit] = "N/A"
 				
-			output_name = os.path.normpath(out_base + "/results/"+qname+"_results.txt")
-		
-			out = open(output_name, "w")
-			out.write("query\ttarget\tavg_jacc_sim\tjacc_SD\tnum_shared_SCPs\tposs_shared_SCPs\tAAI_estimate\n")
-			if do_sd:
-				jaccard_SDs[no_hit] = "N/A"
-				for i in range(0, len(aai_ests)):
-					out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+jaccard_SDs[i]+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
-			else:			
-				for i in range(0, len(aai_ests)):
-					out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+"N/A"+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
-			out.close()
-			
-			
-		else:
-			if store:
-				aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = False)
-				aai_ests[no_hit] = 0
-				#add zeros at misses/NAs
-				holder.append(aai_ests)
+				qname = _qnames[q]
+				output_name = os.path.normpath(out_base + "/results/"+qname+"_results.txt")
+				out = open(output_name, "w")
+				out.write("query\ttarget\tavg_jacc_sim\tjacc_SD\tnum_shared_SCPs\tposs_shared_SCPs\tAAI_estimate\n")
+				if do_sd:
+					jaccard_SDs[no_hit] = "N/A"
+					for i in range(0, len(aai_ests)):
+						out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+jaccard_SDs[i]+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
+				else:			
+					for i in range(0, len(aai_ests)):
+						out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+"N/A"+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
+				out.close()
 			else:
-				aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = True)
+				aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = not store)
 				aai_ests[no_hit] = 0
-				print(*aai_ests, sep = "\t", file = outwriter)
-		
-	result_file = None
-	if style == "matrix":
-		if store:
-			if len(holder) == 0:
-				return (len(query_grouping), None)
-			hold_together = np.vstack(holder)
-			np.savetxt(group_id, hold_together, delimiter = "\t", fmt='%4d')
-			result_file = group_id
-		else:
-			outwriter.close()
-			if len(query_grouping) > 0:
+				if store:
+					holder.append(aai_ests)
+				else:
+					print(*aai_ests, sep = "\t", file = outwriter)
+
+		result_file = None
+		if style == "matrix":
+			if store:
+				if len(holder) == 0:
+					return (len(query_grouping), None)
+				hold_together = np.vstack(holder)
+				np.savetxt(group_id, hold_together, delimiter = "\t", fmt='%4d')
 				result_file = group_id
-	return (len(query_grouping), result_file)
+			elif len(query_grouping) > 0:
+				result_file = group_id
+		return (len(query_grouping), result_file)
+	finally:
+		if outwriter is not None:
+			outwriter.close()
 
 def two_work(i):
 	if store:
@@ -2838,7 +2796,7 @@ def two_work(i):
 		
 	return group_id
 	
-def on_disk_init(query_database_path, target_database_path, num_tgt, query_queue, target_gak, tpres, sd, sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir):
+def on_disk_init(query_database_path, target_database_path, num_tgt, target_gak, tpres, sd, sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir):
 	global database
 	database = sqlite3.connect(":memory:")
 	
@@ -2849,20 +2807,12 @@ def on_disk_init(query_database_path, target_database_path, num_tgt, query_queue
 	
 	global _nt
 	_nt = num_tgt
-	
-	qgak_data = query_queue.get()
-	
+
 	global out_base
 	out_base = output_dir
-	
-	global group_id
-	group_id = os.path.normpath(temp_dir + "/partial_results_group_" + str(qgak_data[0])+ ".txt")
-	
-	global _qgak
-	_qgak = qgak_data[1]
-	
-	global query_grouping
-	query_grouping = qgak_data[2]
+
+	global temp_path
+	temp_path = temp_dir
 	
 	global _tgak
 	_tgak = target_gak
@@ -2895,22 +2845,21 @@ def on_disk_init(query_database_path, target_database_path, num_tgt, query_queue
 	global _valids
 	_valids = valids
 	
-def on_disk_work_one(placeholder):
+def on_disk_work_one(task):
+	task_id, local_qgak, query_grouping = task
+	group_id = os.path.normpath(temp_path + "/partial_results_group_" + str(task_id)+ ".txt")
 	curs = database.cursor()
 	output_rows = []
 	for q in query_grouping:
 		results = []
 		qname = _qnames[q]
-		for acc in _qgak[q][0]:
+		for acc in local_qgak[q][0]:
 			acc_name = acc_indexer[acc]
-				
 			if acc_name in _valids:
-				
 				one = curs.execute("SELECT kmers FROM queries."+acc_name+"_genomes WHERE genome=?", (str(q),)).fetchone()[0]
 				one = np.frombuffer(one, dtype = np.int32)
 				
 				if one.shape[0] > 998:
-					#Each kmer needs to be a tuple.
 					these_kmers = [(int(kmer),) for kmer in one]
 				
 					temp_name = "_" + qname +"_" + acc_name
@@ -2919,12 +2868,9 @@ def on_disk_work_one(placeholder):
 					curs.execute("CREATE TEMP TABLE " + temp_name + " (kmer INTEGER)")
 					insert_table = "INSERT INTO " + temp_name + " VALUES (?)"
 					curs.executemany(insert_table, these_kmers)
-					
 					join_and_select_sql = "SELECT genomes FROM " + temp_name + " INNER JOIN targets." + acc_name + " ON "+ temp_name+".kmer = targets." + acc_name + ".kmer;"
-					
 					matches = curs.execute(join_and_select_sql).fetchall()
 				else:
-					#kmers must be a list, not a tuple.
 					these_kmers = [int(kmer) for kmer in one]
 					select = "SELECT genomes FROM targets." + acc_name + " WHERE kmer IN ({kmers})".format(kmers=','.join(['?']*len(these_kmers)))
 					matches = curs.execute(select, these_kmers).fetchall()
@@ -2933,65 +2879,39 @@ def on_disk_work_one(placeholder):
 				for row in matches:
 					set.append(row[0])
 				set = b''.join(set)
-					
 				matches = None
 				these_intersections = np.bincount(np.frombuffer(set, dtype = np.int32), minlength = _nt)
 				set = None
 				results.append(these_intersections)
-				
 			else:
 				results.append(np.zeros(_nt, dtype=np.int32))
-			
+		
 		results = np.vstack(results)
-		
-		target_kmer_counts = _tgak[_qgak[q][0], :]
-		
-		#unions = size(A) + size(B) - size(intersections(A, B)) 
-		#unions = target_kmer_counts + query_kmers_by_acc - intersections
-		unions = np.subtract(np.add(target_kmer_counts, _qgak[q][1][:, None]), results)
-		
-		#These are now jaccards, not #intersections
+		target_kmer_counts = _tgak[local_qgak[q][0], :]
+		unions = np.subtract(np.add(target_kmer_counts, local_qgak[q][1][:, None]), results)
 		results = np.divide(results, unions)
-
-		shared_acc_counts = np.sum(_tpres[_qgak[q][0], :], axis = 0)
-		
+		shared_acc_counts = np.sum(_tpres[local_qgak[q][0], :], axis = 0)
 		no_hit = np.where(shared_acc_counts == 0)
-		
 		jaccard_averages = np.divide(np.sum(results, axis = 0), shared_acc_counts)
 		
-		#Skip SD if output is matrix
 		if style == "tsv":
 			aai_ests = numpy_kaai_to_aai(jaccard_averages)
 			
 			if do_sd:
-				#find diffs from means; this includes indicies corresponding to unshared SCPs that should not be included. 
 				results = results - jaccard_averages
-				
-				#fix those corresponding indicies to not contribute to the final SD.
-				results[np.logical_not(_tpres[_qgak[q][0], :])] = 0
-				#results[np.nonzero(has_accs == 0)] = 0
-				
-				#Square them; 0^2 = 0, so we don't have to think about the fixed indices any more.
+				results[np.logical_not(_tpres[local_qgak[q][0], :])] = 0
 				results = np.square(results)
-				#Sum squares and divide by shared acc. count, the sqrt to get SD.
 				jaccard_SDs = np.sqrt(np.divide(np.sum(results, axis = 0), shared_acc_counts))
 				jaccard_SDs = np.round(jaccard_SDs, 4).astype(str)
-				
-			no_hit = np.where(shared_acc_counts == 0)
 			
-			#_qgak[q][0] is the query acc count
-			possible_hits = np.minimum(_qgak[q][0].shape[0], _tct).astype(str)
-			
+			possible_hits = np.minimum(local_qgak[q][0].shape[0], _tct).astype(str)
 			jaccard_averages = np.round(jaccard_averages, 4).astype(str)
 			shared_acc_counts = shared_acc_counts.astype(str)
-			
 			jaccard_averages[no_hit] = "N/A"
 			aai_ests[no_hit] = "N/A"
 			shared_acc_counts[no_hit] = "N/A"
 			possible_hits[no_hit] = "N/A"
-			
 			output_name = os.path.normpath(out_base + "/results/"+qname+"_results.txt")
-		
 			out = open(output_name, "w")
 			out.write("query\ttarget\tavg_jacc_sim\tjacc_SD\tnum_shared_SCPs\tposs_shared_SCPs\tAAI_estimate\n")
 			if do_sd:
@@ -3002,12 +2922,11 @@ def on_disk_work_one(placeholder):
 				for i in range(0, len(aai_ests)):
 					out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+"N/A"+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
 			out.close()
-			
 		else:
 			aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = True)
 			aai_ests[no_hit] = 0
 			output_rows.append("\t".join(str(value) for value in aai_ests))
-		
+	
 	curs.close()
 	if style == "matrix":
 		if len(query_grouping) == 0:
@@ -3132,7 +3051,7 @@ class db_db_remake:
 			self.query_gak[genome] = (np.array(self.query_gak[genome][0], dtype = np.int32), np.array(self.query_gak[genome][1], dtype = np.int32))
 		
 		#Split these into ordered groups - this makes joining results at the end easier.
-		qgak_queue = multiprocessing.Queue()
+		query_group_data = []
 		groupings = split_seq_indices(np.arange(self.num_queries), self.threads)
 		group_id = 0
 		for group in groupings:
@@ -3140,12 +3059,11 @@ class db_db_remake:
 			for i in range(group[0], group[1]):
 				next_set[i] = self.query_gak[i]
 				self.query_gak[i] = None
-			#this ensures that the selection of qgak and the query index range match
-			qgak_queue.put((group_id, next_set, np.arange(group[0], group[1]),))
+			query_group_data.append((group_id, next_set, np.arange(group[0], group[1]),))
 			group_id += 1
 		
-		self.query_gak = qgak_queue
-		qgak_queue = None
+		self.query_gak = query_group_data
+		query_group_data = None
 		
 		#tgt gak is organized by accession first, then genome
 		self.target_gak = np.zeros(shape = (122, self.num_targets), dtype = np.int32)
@@ -3205,16 +3123,12 @@ class db_db_remake:
 		else:
 			print("\nCalculating AAI.")
 		
-		query_groups = []
-		for grouping in split_seq_indices(np.arange(self.num_queries), self.threads):
-			query_groups.append(np.arange(grouping[0], grouping[1]))
-		self.num_result_groups = len(query_groups)
+		self.num_result_groups = len(self.query_gak)
 		
 		pool = multiprocessing.Pool(self.threads, initializer = one_init, 
 		initargs = (ql, #ql 
 					tl, #tl
 					self.num_targets, #num_tgt
-					self.query_gak, #qgak_queue
 					self.target_gak, #tgak
 					self.target_presence, #tpres
 					self.do_sd, #sd
@@ -3226,7 +3140,7 @@ class db_db_remake:
 					self.target_names, #tnames
 					tempdir_path,)) #temp_dir
 		
-		some_results = pool.imap(one_work, query_groups)
+		some_results = pool.imap(one_work, self.query_gak)
 		
 		if self.style == "matrix":
 			result_files = []
@@ -3258,10 +3172,7 @@ class db_db_remake:
 		else:
 			print("\nCalculating AAI")
 		
-		query_groups = []
-		for grouping in split_seq_indices(np.arange(self.num_queries), self.threads):
-			query_groups.append(np.arange(grouping[0], grouping[1]))
-		self.num_result_groups = len(query_groups)
+		self.num_result_groups = len(self.query_gak)
 		
 		#query_database_path, target_database_path, num_tgt, query_queue, target_gak, tpres, sd, 
 		#sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir
@@ -3269,7 +3180,6 @@ class db_db_remake:
 		initargs = (self.q, #query_database_path
 					self.t, #target_database_path
 					self.num_targets, #num_tgt
-					self.query_gak, #query_queue
 					self.target_gak, #target_gak
 					self.target_presence, #tpres
 					self.do_sd, #sd
@@ -3281,7 +3191,7 @@ class db_db_remake:
 					self.valids, #valids
 					tempdir_path,)) #temp_dir
 		
-		some_results = pool.imap(on_disk_work_one, query_groups)
+		some_results = pool.imap(on_disk_work_one, self.query_gak)
 		
 		if self.style == "matrix":
 			result_files = []

--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -2708,7 +2708,7 @@ def one_init(ql, tl, num_tgt, tgak, tpres, sd, sty, output_dir, store_results, p
 	global _tnames
 	_tnames = tnames
 	
-def one_work(task):	
+def one_work(task):
 	task_id, local_qgak, query_grouping = task
 	group_id = os.path.normpath(temp_path + "/partial_results_group_" + str(task_id)+ ".txt")
 	holder = []
@@ -2760,7 +2760,7 @@ def one_work(task):
 					jaccard_SDs[no_hit] = "N/A"
 					for i in range(0, len(aai_ests)):
 						out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+jaccard_SDs[i]+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
-				else:			
+				else:
 					for i in range(0, len(aai_ests)):
 						out.write(qname+"\t"+_tnames[i]+"\t"+jaccard_averages[i]+"\t"+"N/A"+"\t"+shared_acc_counts[i]+"\t"+possible_hits[i]+"\t"+aai_ests[i]+"\n")
 				out.close()
@@ -2795,11 +2795,11 @@ def two_work(i):
 		outwriter.close()
 		
 	return group_id
-	
+
 def on_disk_init(query_database_path, target_database_path, num_tgt, target_gak, tpres, sd, sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir):
 	global database
 	database = sqlite3.connect(":memory:")
-	
+
 	curs = database.cursor()
 	curs.execute("attach '" + query_database_path + "' as queries")
 	curs.execute("attach '" + target_database_path + "' as targets")
@@ -2926,7 +2926,7 @@ def on_disk_work_one(task):
 			aai_ests = numpy_kaai_to_aai_just_nums(jaccard_averages, as_float = True)
 			aai_ests[no_hit] = 0
 			output_rows.append("\t".join(str(value) for value in aai_ests))
-	
+
 	curs.close()
 	if style == "matrix":
 		if len(query_grouping) == 0:
@@ -3123,7 +3123,7 @@ class db_db_remake:
 		else:
 			print("\nCalculating AAI.")
 		
-		self.num_result_groups = len(self.query_gak)
+		self.num_result_groups = self.count_result_groups()
 		
 		pool = multiprocessing.Pool(self.threads, initializer = one_init, 
 		initargs = (ql, #ql 
@@ -3172,7 +3172,7 @@ class db_db_remake:
 		else:
 			print("\nCalculating AAI")
 		
-		self.num_result_groups = len(self.query_gak)
+		self.num_result_groups = self.count_result_groups()
 		
 		#query_database_path, target_database_path, num_tgt, query_queue, target_gak, tpres, sd, 
 		#sty, output_dir, progress_queue, qnames, tnames, valids, temp_dir
@@ -3212,6 +3212,10 @@ class db_db_remake:
 		if self.style == "matrix":
 			self.write_mat_from_files(result_files, tempdir_path)
 			
+	def count_result_groups(self):
+		"""Return the number of non-empty query groups that produce files."""
+		return sum(1 for _, _, query_grouping in self.query_gak if len(query_grouping) > 0)
+
 	def validate_result_files(self, result_files):
 		"""Validate matrix partial result files before combining them."""
 		if len(result_files) != self.num_result_groups:
@@ -4798,5 +4802,3 @@ def main():
 	
 if __name__ == "__main__":
 	main()
-
-	

--- a/tests/test_in_memory_db_query.py
+++ b/tests/test_in_memory_db_query.py
@@ -1,0 +1,104 @@
+"""Tests for the in-memory database-query path."""
+
+import io
+import sqlite3
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import numpy as np
+
+from fastaai.fastaai import db_query
+from fastaai.fastaai import flatten_cached_targets
+from fastaai.fastaai import generate_accessions_index
+
+
+def _create_minimal_database(database_path: Path) -> None:
+	"""Create a two-genome FastAAI database for query tests."""
+	accession = "PF01780_19"
+	accession_id = generate_accessions_index()[accession]
+	genome_kmers = {
+		0: np.array([1, 2], dtype = np.int32),
+		1: np.array([1, 3], dtype = np.int32),
+	}
+	kmer_genomes = {
+		1: np.array([0, 1], dtype = np.int32),
+		2: np.array([0], dtype = np.int32),
+		3: np.array([1], dtype = np.int32),
+	}
+
+	with sqlite3.connect(database_path) as connection:
+		connection.execute("CREATE TABLE genome_index (genome text, gen_id integer, protein_count integer)")
+		connection.execute("CREATE TABLE genome_acc_kmer_counts (genome integer, accession integer, count integer)")
+		connection.execute(f"CREATE TABLE {accession}_genomes (genome INTEGER PRIMARY KEY, kmers array)")
+		connection.execute(f"CREATE TABLE {accession} (kmer INTEGER PRIMARY KEY, genomes array)")
+		connection.executemany(
+			"INSERT INTO genome_index VALUES (?, ?, ?)",
+			[("genome_0", 0, 1), ("genome_1", 1, 1)],
+		)
+		connection.executemany(
+			"INSERT INTO genome_acc_kmer_counts VALUES (?, ?, ?)",
+			[(genome, accession_id, len(kmers)) for genome, kmers in genome_kmers.items()],
+		)
+		connection.executemany(
+			f"INSERT INTO {accession}_genomes VALUES (?, ?)",
+			[(genome, kmers.tobytes()) for genome, kmers in genome_kmers.items()],
+		)
+		connection.executemany(
+			f"INSERT INTO {accession} VALUES (?, ?)",
+			[(kmer, genomes.tobytes()) for kmer, genomes in kmer_genomes.items()],
+		)
+
+
+class InMemoryDbQueryTests(unittest.TestCase):
+	"""Verify cached in-memory target lists stay integer-typed."""
+
+	def test_flatten_cached_targets_returns_int_array(self):
+		"""Flatten cached target hits into one integer array."""
+		target_hits = np.array(
+			[
+				np.array([1, 2], dtype = np.int32),
+				np.array([3, 4], dtype = np.int32),
+			],
+			dtype = object,
+		)
+		selection = np.array([0, 1], dtype = np.int32)
+
+		flattened = flatten_cached_targets(target_hits, selection)
+
+		self.assertEqual(flattened.dtype, np.int32)
+		np.testing.assert_array_equal(flattened, np.array([1, 2, 3, 4], dtype = np.int32))
+		np.testing.assert_array_equal(np.bincount(flattened, minlength = 5), np.array([0, 1, 1, 1, 1]))
+
+	def test_db_query_in_memory_completes_on_small_example_db(self):
+		"""Run the in-memory query path on a two-genome example database."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			tempdir_path = Path(tempdir)
+			database_path = tempdir_path / "mini.db"
+			query_output = tempdir_path / "query"
+			_create_minimal_database(database_path)
+
+			with redirect_stdout(io.StringIO()):
+				db_query(
+					query = str(database_path),
+					target = str(database_path),
+					verbose = False,
+					output = str(query_output),
+					threads = 4,
+					do_stdev = False,
+					style = "tsv",
+					in_mem = True,
+					store_results = False,
+				)
+
+			results_dir = query_output / "results"
+			result_files = sorted(results_dir.glob("*_results.txt"))
+			self.assertEqual(len(result_files), 2)
+			for result_file in result_files:
+				content = result_file.read_text(encoding = "ascii")
+				self.assertIn("query\ttarget\tavg_jacc_sim", content)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_matrix_output.py
+++ b/tests/test_matrix_output.py
@@ -1,0 +1,48 @@
+"""Tests for matrix output bookkeeping."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastaai.fastaai import db_db_remake
+
+
+class MatrixOutputTests(unittest.TestCase):
+	"""Verify matrix partial files are validated before merging."""
+
+	def test_validate_result_files_accepts_expected_unique_files(self):
+		"""Accept the expected set of unique existing files."""
+		remake = db_db_remake()
+		with tempfile.TemporaryDirectory() as tempdir:
+			paths = []
+			for index in range(2):
+				path = Path(tempdir) / f"part_{index}.txt"
+				path.write_text("1\t2\n", encoding="ascii")
+				paths.append(str(path))
+			remake.num_result_groups = len(paths)
+			remake.validate_result_files(paths)
+
+	def test_validate_result_files_rejects_duplicate_paths(self):
+		"""Reject duplicate file paths before matrix merge."""
+		remake = db_db_remake()
+		with tempfile.TemporaryDirectory() as tempdir:
+			path = Path(tempdir) / "part.txt"
+			path.write_text("1\t2\n", encoding="ascii")
+			remake.num_result_groups = 2
+			with self.assertRaises(RuntimeError):
+				remake.validate_result_files([str(path), str(path)])
+
+	def test_validate_result_files_rejects_missing_paths(self):
+		"""Reject missing files before matrix merge."""
+		remake = db_db_remake()
+		with tempfile.TemporaryDirectory() as tempdir:
+			path = Path(tempdir) / "part.txt"
+			path.write_text("1\t2\n", encoding="ascii")
+			missing = Path(tempdir) / "missing.txt"
+			remake.num_result_groups = 2
+			with self.assertRaises(RuntimeError):
+				remake.validate_result_files([str(path), str(missing)])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_matrix_output.py
+++ b/tests/test_matrix_output.py
@@ -1,14 +1,68 @@
 """Tests for matrix output bookkeeping."""
 
+import io
+import sqlite3
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
+import numpy as np
+
 from fastaai.fastaai import db_db_remake
+from fastaai.fastaai import db_query
+from fastaai.fastaai import generate_accessions_index
+
+
+def _create_minimal_database(database_path: Path) -> None:
+	"""Create a two-genome FastAAI database for query bookkeeping tests."""
+	accession = "PF01780_19"
+	accession_id = generate_accessions_index()[accession]
+	genome_kmers = {
+		0: np.array([1, 2], dtype = np.int32),
+		1: np.array([1, 3], dtype = np.int32),
+	}
+	kmer_genomes = {
+		1: np.array([0, 1], dtype = np.int32),
+		2: np.array([0], dtype = np.int32),
+		3: np.array([1], dtype = np.int32),
+	}
+
+	with sqlite3.connect(database_path) as connection:
+		connection.execute("CREATE TABLE genome_index (genome text, gen_id integer, protein_count integer)")
+		connection.execute("CREATE TABLE genome_acc_kmer_counts (genome integer, accession integer, count integer)")
+		connection.execute(f"CREATE TABLE {accession}_genomes (genome INTEGER PRIMARY KEY, kmers array)")
+		connection.execute(f"CREATE TABLE {accession} (kmer INTEGER PRIMARY KEY, genomes array)")
+		connection.executemany(
+			"INSERT INTO genome_index VALUES (?, ?, ?)",
+			[("genome_0", 0, 1), ("genome_1", 1, 1)],
+		)
+		connection.executemany(
+			"INSERT INTO genome_acc_kmer_counts VALUES (?, ?, ?)",
+			[(genome, accession_id, len(kmers)) for genome, kmers in genome_kmers.items()],
+		)
+		connection.executemany(
+			f"INSERT INTO {accession}_genomes VALUES (?, ?)",
+			[(genome, kmers.tobytes()) for genome, kmers in genome_kmers.items()],
+		)
+		connection.executemany(
+			f"INSERT INTO {accession} VALUES (?, ?)",
+			[(kmer, genomes.tobytes()) for kmer, genomes in kmer_genomes.items()],
+		)
 
 
 class MatrixOutputTests(unittest.TestCase):
 	"""Verify matrix partial files are validated before merging."""
+
+	def test_count_result_groups_ignores_empty_worker_groups(self):
+		"""Expect files only from worker groups that contain queries."""
+		remake = db_db_remake()
+		remake.query_gak = [
+			(0, {0: object()}, [0]),
+			(1, {}, []),
+		]
+
+		self.assertEqual(remake.count_result_groups(), 1)
 
 	def test_validate_result_files_accepts_expected_unique_files(self):
 		"""Accept the expected set of unique existing files."""
@@ -42,6 +96,33 @@ class MatrixOutputTests(unittest.TestCase):
 			remake.num_result_groups = 2
 			with self.assertRaises(RuntimeError):
 				remake.validate_result_files([str(path), str(missing)])
+
+	def test_matrix_query_handles_more_threads_than_genomes(self):
+		"""Complete an on-disk matrix query when some worker groups are empty."""
+		with tempfile.TemporaryDirectory() as tempdir:
+			tempdir_path = Path(tempdir)
+			database_path = tempdir_path / "mini.db"
+			query_output = tempdir_path / "query"
+			_create_minimal_database(database_path)
+
+			with redirect_stdout(io.StringIO()):
+				db_query(
+					query = str(database_path),
+					target = str(database_path),
+					verbose = False,
+					output = str(query_output),
+					threads = 8,
+					do_stdev = False,
+					style = "matrix",
+					in_mem = False,
+					store_results = False,
+				)
+
+			matrix_path = query_output / "results" / "FastAAI_matrix.txt"
+			matrix_rows = matrix_path.read_text(encoding = "ascii").splitlines()
+			self.assertEqual(len(matrix_rows), 3)
+			for row in matrix_rows:
+				self.assertEqual(len(row.split("\t")), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix database-query workers that could stall or produce missing and duplicate matrix files.

- pass query groups to workers explicitly
- consume worker results directly instead of relying on a progress side-channel
- validate matrix fragments before merging, including empty high-thread worker groups
- convert cached in-memory hits to `int32` before `numpy.bincount`

Tests: `python -m unittest tests.test_matrix_output tests.test_in_memory_db_query` (7 passed)

Closes #16
Closes #24
