### PR TITLE
fix: sanitise temporary SQLite identifiers

### DIFF
--- a/fastaai/fastaai.py
+++ b/fastaai/fastaai.py
@@ -139,6 +139,22 @@ def read_fasta(file):
 		deflines[cur_prot] = defline
 		
 	return contents, deflines
+
+
+def safe_sql_identifier(value):
+	"""Return a SQLite-safe identifier fragment."""
+	safe_value = re.sub(r"[^0-9A-Za-z_]+", "_", str(value))
+	safe_value = re.sub(r"_+", "_", safe_value).strip("_")
+	if len(safe_value) == 0:
+		safe_value = "value"
+	if safe_value[0].isdigit():
+		safe_value = "n_" + safe_value
+	return safe_value
+
+
+def build_temp_table_name(query_name, accession_name):
+	"""Build a temporary table name that is safe for SQLite."""
+	return "tmp_" + safe_sql_identifier(query_name) + "_" + safe_sql_identifier(accession_name)
 	
 class fasta_file:
 	def __init__(self, file, type = "genome"):
@@ -1846,8 +1862,7 @@ def file_v_db_worker(query_args):
 				#Each kmer needs to be a tuple.
 				these_kmers = [(int(kmer),) for kmer in one]
 			
-				temp_name = "_" + qname +"_" + acc
-				temp_name = temp_name.replace(".", "_")
+				temp_name = build_temp_table_name(qname, acc)
 				
 				tcurs.execute("CREATE TEMP TABLE " + temp_name + " (kmer INTEGER)")
 				tconn.commit()
@@ -2908,8 +2923,7 @@ def on_disk_work_one(placeholder):
 					#Each kmer needs to be a tuple.
 					these_kmers = [(int(kmer),) for kmer in one]
 				
-					temp_name = "_" + qname +"_" + acc_name
-					temp_name = temp_name.replace(".", "_")
+					temp_name = build_temp_table_name(qname, acc_name)
 					
 					curs.execute("CREATE TEMP TABLE " + temp_name + " (kmer INTEGER)")
 					insert_table = "INSERT INTO " + temp_name + " VALUES (?)"

--- a/tests/test_sql_temp_tables.py
+++ b/tests/test_sql_temp_tables.py
@@ -1,0 +1,25 @@
+"""Tests for temporary SQLite table naming."""
+
+import sqlite3
+import unittest
+
+from fastaai.fastaai import build_temp_table_name
+
+
+class SqlTempTableTests(unittest.TestCase):
+	"""Verify generated temporary table names stay SQLite-safe."""
+
+	def test_build_temp_table_name_handles_digit_prefixed_query_names(self):
+		"""Generate temp table names that SQLite can create directly."""
+		temp_name = build_temp_table_name("11_0_1__xyz", "PF01813.17")
+		self.assertTrue(temp_name.startswith("tmp_n_11_0_1_xyz_PF01813_17"))
+
+		conn = sqlite3.connect(":memory:")
+		try:
+			conn.execute("CREATE TEMP TABLE " + temp_name + " (kmer INTEGER)")
+		finally:
+			conn.close()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Make temporary SQLite table names safe when genome identifiers begin with numbers or contain punctuation. Scientific identifiers and output names are unchanged.

Test: `python -m unittest tests.test_sql_temp_tables` (1 passed)

Closes #15
